### PR TITLE
Fix header link to About section

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,7 +5,7 @@
     </div>
     <ul class="navbar-items">
       <li><a href="/">Home</a></li>
-      <li><a href="/about">About</a></li>
+      <li><a href="#about">About</a></li>
     </ul>
   </nav>
 </header>


### PR DESCRIPTION
## Summary
- fix About link in custom header to anchor on the page

## Testing
- `go vet ./...` *(fails: missing go.sum entry)*
- `go mod tidy` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684842a46de083329a2d8bd375076def